### PR TITLE
Fix deprecations in PHP8.1

### DIFF
--- a/examples/05-date-support.php
+++ b/examples/05-date-support.php
@@ -19,7 +19,7 @@ class DateSubLexer implements SubLexerInterface
      */
     public function getTokenAt($code, $cursor)
     {
-        if (!preg_match('/(?<y>\d{4})-(?<m>\d{2})-(?<d>\d{2})/A', $code, $matches, null, $cursor)) {
+        if (!preg_match('/(?<y>\d{4})-(?<m>\d{2})-(?<d>\d{2})/A', $code, $matches, 0, $cursor)) {
             return null;
         }
 

--- a/examples/08-string-quoting.php
+++ b/examples/08-string-quoting.php
@@ -34,7 +34,7 @@ class IdentifierSubLexer implements SubLexerInterface
      */
     public function getTokenAt($code, $cursor)
     {
-        if (!preg_match('/[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]*)*/Ai', $code, $matches, null, $cursor)) {
+        if (!preg_match('/[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]*)*/Ai', $code, $matches, 0, $cursor)) {
             return null;
         }
 
@@ -57,7 +57,7 @@ class StringSubLexer implements SubLexerInterface
      */
     public function getTokenAt($code, $cursor)
     {
-        if (!preg_match('/"(?:\\\\"|.)*?"/A', $code, $matches, null, $cursor)) {
+        if (!preg_match('/"(?:\\\\"|.)*?"/A', $code, $matches, 0, $cursor)) {
             return null;
         }
 
@@ -86,7 +86,7 @@ class ConstantSubLexer implements SubLexerInterface
             'null' => Token::T_NULL,
         ];
 
-        if (!preg_match('/(?:true|false|null)/A', $code, $matches, null, $cursor)) {
+        if (!preg_match('/(?:true|false|null)/A', $code, $matches, 0, $cursor)) {
             return null;
         }
 

--- a/src/SubLexer/DatetimeSubLexer.php
+++ b/src/SubLexer/DatetimeSubLexer.php
@@ -13,7 +13,7 @@ class DatetimeSubLexer implements SubLexerInterface
     public function getTokenAt($code, $cursor)
     {
         $regExp = '/(?<y>\d{4})-(?<m>\d{2})-(?<d>\d{2})T(?<h>\d{2}):(?<i>\d{2}):(?<s>\d{2})(?<tz>(Z|[\+|-]\d{4}))/A';
-        if (!preg_match($regExp, $code, $matches, null, $cursor)) {
+        if (!preg_match($regExp, $code, $matches, 0, $cursor)) {
             return null;
         }
 

--- a/src/SubLexer/FiqlOperatorSubLexer.php
+++ b/src/SubLexer/FiqlOperatorSubLexer.php
@@ -25,7 +25,7 @@ class FiqlOperatorSubLexer implements SubLexerInterface
      */
     public function getTokenAt($code, $cursor)
     {
-        if (!preg_match('/(=[a-z]\w*=|==|!=|<>|>=|<=|<|>|==|=)/Ai', $code, $matches, null, $cursor)) {
+        if (!preg_match('/(=[a-z]\w*=|==|!=|<>|>=|<=|<|>|==|=)/Ai', $code, $matches, 0, $cursor)) {
             return null;
         }
 

--- a/src/SubLexer/GlobSubLexer.php
+++ b/src/SubLexer/GlobSubLexer.php
@@ -12,7 +12,7 @@ class GlobSubLexer implements SubLexerInterface
      */
     public function getTokenAt($code, $cursor)
     {
-        if (!preg_match('/([a-z0-9\*\?-]|\%[0-9a-f]{2})+/Ai', $code, $matches, null, $cursor)) {
+        if (!preg_match('/([a-z0-9\*\?-]|\%[0-9a-f]{2})+/Ai', $code, $matches, 0, $cursor)) {
             return null;
         } elseif (strpos($matches[0], '?') === false && strpos($matches[0], '*') === false) {
             return null;

--- a/src/SubLexer/NumberSubLexer.php
+++ b/src/SubLexer/NumberSubLexer.php
@@ -11,7 +11,7 @@ class NumberSubLexer implements SubLexerInterface
      */
     public function getTokenAt($code, $cursor)
     {
-        if (!preg_match('/[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?/A', $code, $matches, null, $cursor)) {
+        if (!preg_match('/[-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?/A', $code, $matches, 0, $cursor)) {
             return null;
         }
 

--- a/src/SubLexer/RqlOperatorSubLexer.php
+++ b/src/SubLexer/RqlOperatorSubLexer.php
@@ -11,7 +11,7 @@ class RqlOperatorSubLexer implements SubLexerInterface
      */
     public function getTokenAt($code, $cursor)
     {
-        if (!preg_match('/[a-z]\w*(?=\()/Ai', $code, $matches, null, $cursor)) {
+        if (!preg_match('/[a-z]\w*(?=\()/Ai', $code, $matches, 0, $cursor)) {
             return null;
         }
 

--- a/src/SubLexer/StringSubLexer.php
+++ b/src/SubLexer/StringSubLexer.php
@@ -11,7 +11,7 @@ class StringSubLexer implements SubLexerInterface
      */
     public function getTokenAt($code, $cursor)
     {
-        if (!preg_match('/([a-z0-9]|\%[0-9a-f]{2})+/Ai', $code, $matches, null, $cursor)) {
+        if (!preg_match('/([a-z0-9]|\%[0-9a-f]{2})+/Ai', $code, $matches, 0, $cursor)) {
             return null;
         } elseif (ctype_digit($matches[0])) {
             return null;

--- a/src/SubLexer/TypeSubLexer.php
+++ b/src/SubLexer/TypeSubLexer.php
@@ -11,7 +11,7 @@ class TypeSubLexer implements SubLexerInterface
      */
     public function getTokenAt($code, $cursor)
     {
-        if (!preg_match('/[a-z]\w*(?=:)/Ai', $code, $matches, null, $cursor)) {
+        if (!preg_match('/[a-z]\w*(?=:)/Ai', $code, $matches, 0, $cursor)) {
             return null;
         }
 

--- a/src/TokenStream.php
+++ b/src/TokenStream.php
@@ -26,7 +26,7 @@ class TokenStream implements \Countable
     /**
      * @inheritdoc
      */
-    public function count()
+    public function count(): int
     {
         return count($this->tokens);
     }


### PR DESCRIPTION
These are the deprecations I found while updating our internal projects to PHP8.1

**Deprecation 1: Internal-method-return-types**

Since PHP8.1 built-in classes are updated with tentative return types.

https://php.watch/versions/8.1/internal-method-return-types

This alteration doesn't impact older PHP versions which may use this package (>=7.2.0). Return types were introduced back in PHP7.0 and nullable types were added in PHP 7.1.

**Deprecation 2: Passing null to non-nullable internal function parameters**

Passing null to a function/method parameter that is not declared nullable is not allowed.

https://php.watch/versions/8.1/internal-func-non-nullable-null-deprecation

This impacted the way preg_match was used. Changing the third paramter from null to the default value, 0, fixes this.