### PR TITLE
Fix value in unexpected token error message

### DIFF
--- a/src/TokenStream.php
+++ b/src/TokenStream.php
@@ -109,7 +109,7 @@ class TokenStream implements \Countable
                                     function ($value) {
                                         return '"' . $value . '"';
                                     },
-                                    (array)$type
+                                    (array)$value
                                 )
                             ),
                             implode(


### PR DESCRIPTION
A simple fix for an incorrect variable reference that results in an error message like

```Unexpected token "value" (T_STRING) (expected "41" (T_OPERATOR))```

where the token type constant is displayed rather than the expected value(s). For testing, nothing in the standard grammar can trigger this error, so it can't currently be added to `ParserTest`, and is probably why it slipped through the cracks. I'm happy to write a test on `TokenStream` that mocks a situation to test this issue, or add something to `ParserTest`'s parser chain that could trigger this, but I wasn't sure what your preference would be.